### PR TITLE
Fix building nextpnr-ecp5 and package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ Installing a simple toolchain is as easy as running the following:
 
 ```
 $ brew tap ktemkin/oss-fpga
-$ brew install --HEAD project-trellis yosys nextpnr-trellis
+$ brew install --HEAD project-trellis yosys nextpnr-ecp5
 ```

--- a/project-trellis.rb
+++ b/project-trellis.rb
@@ -1,7 +1,7 @@
 class ProjectTrellis < Formula
   desc "tools for documenting and working with ECP5 FPGA files"
-  homepage "https://github.com/SymbiFlow/prjtrellis"
-  head "https://github.com/SymbiFlow/prjtrellis.git"
+  homepage "https://github.com/YosysHQ/prjtrellis"
+  head "https://github.com/YosysHQ/prjtrellis.git"
 
   depends_on "cmake" => :build
   depends_on "boost-python3" => :build


### PR DESCRIPTION
nextpnr-ecp5 now requires pjtrellis from YosysHQ.