### PR TITLE
Fix builds of `nextpnr-ice40` on recent Mac OS X versions

### DIFF
--- a/icestorm.rb
+++ b/icestorm.rb
@@ -7,7 +7,6 @@ class Icestorm < Formula
   depends_on "gnu-sed" => :build
   depends_on "libftdi"
   depends_on "python"
-  depends_on "icestorm"
 
   def install
 

--- a/nextpnr-ice40.rb
+++ b/nextpnr-ice40.rb
@@ -7,13 +7,21 @@ class NextpnrIce40 < Formula
   depends_on "pkg-config" => :build
   depends_on "eigen" => :build
   depends_on "python@3.9"
-  depends_on "boost"
+  depends_on "boost@1.85"
   depends_on "boost-python3"
   depends_on "icestorm"
 
   def install
+    boost = Formula["boost@1.85"]
+    icestorm = Formula["icestorm"]
+
+    ENV["CMAKE_PREFIX_PATH"] = boost.opt_prefix
+
     mkdir "build" do
-      system "cmake", "..", "-DARCH=ice40", *std_cmake_args, "-DBoost_NO_BOOST_CMAKE=on", "-DBUILD_TESTS=OFF", "-DICEBOX_ROOT=#{HOMEBREW_PREFIX}/share/icebox"
+      system "cmake", "..",
+             "-DARCH=ice40",
+             "-DICESTORM_INSTALL_PREFIX=#{icestorm.opt_prefix}",
+             *std_cmake_args
       system "make", "install"
     end
   end

--- a/nextpnr-ice40.rb
+++ b/nextpnr-ice40.rb
@@ -9,12 +9,13 @@ class NextpnrIce40 < Formula
   depends_on "python@3.9"
   depends_on "boost"
   depends_on "boost-python3"
-  depends_on "qt5"
   depends_on "icestorm"
 
   def install
-    system "cmake", "-DARCH=ice40", ".", *std_cmake_args, "-DBoost_NO_BOOST_CMAKE=on", "-DBUILD_TESTS=OFF", "-DICEBOX_ROOT=#{HOMEBREW_PREFIX}/share/icebox"
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", "-DARCH=ice40", *std_cmake_args, "-DBoost_NO_BOOST_CMAKE=on", "-DBUILD_TESTS=OFF", "-DICEBOX_ROOT=#{HOMEBREW_PREFIX}/share/icebox"
+      system "make", "install"
+    end
   end
 
 end


### PR DESCRIPTION
Tested on Sequoia on an M3 air.  

Thanks for creating this tap!